### PR TITLE
Updated pip command calls to be compatible with latest version of pip

### DIFF
--- a/pypi_mirror/cmd/run_mirror.py
+++ b/pypi_mirror/cmd/run_mirror.py
@@ -173,10 +173,10 @@ class Mirror(object):
     def build_mirror(self, mirror):
         print("Building mirror: %s" % mirror['name'])
         pip_format = (
-            "%(pip)s download -U %(extra_args)s --exists-action=w"
+            "%(pip)s download %(extra_args)s --exists-action=w"
             " --dest %(download_cache)s"
             " --build %(build_dir)s -f %(find_links)s"
-            " --no-binary:all:"
+            " --no-binary :all:"
             " -r %(requirements_file)s")
         venv_format = (
             "virtualenv --clear %(venv_dir)s")
@@ -260,7 +260,7 @@ class Mirror(object):
                     "distribute"]
 
                 for requirement in build_tools:
-                    for extra_args in ("", "--no-use-wheel"):
+                    for extra_args in ("", "--no-binary :all:"):
                         self.run_command(
                             upgrade_format % dict(
                                 pip=pip, extra_args=extra_args,
@@ -313,7 +313,7 @@ class Mirror(object):
                 self.run_command(venv_format % dict(
                     extra_search_dir=pip_cache_dir, venv_dir=venv))
                 for requirement in ["pip", "wheel"]:
-                    for extra_args in ("", "--no-use-wheel"):
+                    for extra_args in ("", "--no-binary :all:"):
                         self.run_command(
                             upgrade_format % dict(
                                 pip=pip, extra_args=extra_args,

--- a/pypi_mirror/cmd/run_mirror.py
+++ b/pypi_mirror/cmd/run_mirror.py
@@ -173,23 +173,21 @@ class Mirror(object):
     def build_mirror(self, mirror):
         print("Building mirror: %s" % mirror['name'])
         pip_format = (
-            "%(pip)s install -U %(extra_args)s --exists-action=w"
-            " --download %(download_cache)s"
+            "%(pip)s download -U %(extra_args)s --exists-action=w"
+            " --dest %(download_cache)s"
             " --build %(build_dir)s -f %(find_links)s"
-            " --no-use-wheel"
+            " --no-binary:all:"
             " -r %(requirements_file)s")
         venv_format = (
             "virtualenv --clear %(venv_dir)s")
         upgrade_format = (
-            "%(pip)s install -U --exists-action=w"
+            "%(pip)s download --exists-action=w"
             " -f %(find_links)s %(requirement)s")
         wheel_file_format = (
-            "%(pip)s wheel --download %(download_cache)s"
-            " --wheel-dir %(wheel_dir)s -f %(find_links)s"
+            "%(pip)s wheel --wheel-dir %(wheel_dir)s -f %(find_links)s"
             " -r %(requirements_file)s")
         wheel_format = (
-            "%(pip)s wheel --download %(download_cache)s"
-            " -f %(find_links)s --wheel-dir %(wheel_dir)s %(requirement)s")
+            "%(pip)s wheel -f %(find_links)s --wheel-dir %(wheel_dir)s %(requirement)s")
 
         workdir = tempfile.mkdtemp()
         reqs = os.path.join(workdir, "reqs")


### PR DESCRIPTION
- Changed pip install calls to pip download as this is compatible with the latest version of pip
- Also changed any other relevant switches to the latest non-deprecated switches for pip download and pip wheel
- Swapped out --no-use-wheel for --no-binary :all:
